### PR TITLE
Updates pump version, fixes cmd config argument

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:jessie-slim
 
-ENV TYKVERSION 0.5.0
+ENV TYKVERSION 0.5.1
 
 LABEL Description="Tyk Pump docker image" Vendor="Tyk" Version=$TYKVERSION
 
@@ -8,7 +8,7 @@ RUN apt-get update \
  && apt-get upgrade -y \
  && apt-get install -y --no-install-recommends \
             curl ca-certificates apt-transport-https \
- && curl https://packagecloud.io/gpg.key | apt-key add - \
+ && curl -L https://packagecloud.io/tyk/tyk-pump/gpgkey | apt-key add - \
  && apt-get autoremove -y \
  && rm -rf /root/.cache
 
@@ -22,4 +22,4 @@ VOLUME ["/opt/tyk-pump/"]
 
 WORKDIR /opt/tyk-pump
 
-CMD ["/opt/tyk-pump/tyk-pump", "--c=/opt/tyk-pump/pump.conf"]
+CMD ["/opt/tyk-pump/tyk-pump", "-c", "/opt/tyk-pump/pump.conf"]


### PR DESCRIPTION
Due to a change in command line processing in 0.5.0 `--c` is no longer a valid way to specify a config file (only `-c` and `--conf` are). Also this should be updated to the latest release.

Fixes https://github.com/TykTechnologies/tyk-pump/issues/64.